### PR TITLE
Added CommandProcessor AutoRun

### DIFF
--- a/atomics/T1547.001/T1547.001.yaml
+++ b/atomics/T1547.001/T1547.001.yaml
@@ -138,4 +138,24 @@ atomic_tests:
       $Create.Save()      
     cleanup_command: Remove-Item "$home\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\calc_exe.lnk" -ErrorAction Ignore
     name: powershell
-    elevation_required: true 
+    elevation_required: true
+
+- name: Persistence using CommandProcessor AutoRun key (With Elevation)
+  auto_generated_guid: a574dafe-a903-4cce-9701-14040f4f3532
+  description:  |-
+    An adversary may abuse the CommandProcessor AutoRun registry key to persist. Every time cmd.exe is executed, the command defined in the AutoRun key gets executed.
+    [reference](https://devblogs.microsoft.com/oldnewthing/20071121-00/?p=24433)
+  supported_platforms:
+  - windows
+  input_arguments:
+    command:
+      description: Command to Execute
+      type: string
+      default: calc.exe
+  executor:
+    command: |- 
+      New-ItemProperty -Path "HKLM:\Software\Microsoft\Command Processor" -Name "AutoRun" -Value "#{command}" -PropertyType "String"
+    cleanup_command: |-
+      Remove-ItemProperty -Path "HKLM:\Software\Microsoft\Command Processor" -Name "AutoRun"
+    name: powershell
+    elevation_required: true


### PR DESCRIPTION
Persistence using CommandProcessor AutoRun key (With Elevation)

**Details:**
Any command that is set as a value for AutoRun key within HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor gets executed whenever cmd.exe is spawned. 

**Testing:**
Tested locally using ART

**Associated Issues:**
N/A