### PR TITLE
Create T1098.003.yaml

### DIFF
--- a/atomics/T1098.003/T1098.003.yaml
+++ b/atomics/T1098.003/T1098.003.yaml
@@ -1,0 +1,38 @@
+- name: Azure AD - Add Company Administrator Role to a user
+  auto_generated_guid: 4d77f913-56f5-4a14-b4b1-bf7bb24298ad
+  description: |
+    Add an existing Azure user account the Company Administrator Role.
+  supported_platforms:
+  - azure-ad
+  input_arguments:
+    username:
+      description: Azure AD username
+      type: string
+      default: jonh@contoso.com
+    password:
+      description: Azure AD password
+      type: string
+      default: p4sswd
+    target_user:
+      description: Name of the user who will be assigned the Company Admin role
+      type: string
+      default: default
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+     MSOnline module must be installed.
+    prereq_command: |
+      try {if (Get-InstalledModule -Name MSOnline -ErrorAction SilentlyContinue) {exit 0} else {exit 1}} catch {exit 1}
+    get_prereq_command: |
+      Install-Module -Name MSOnline -Force
+  executor:
+    command: |
+      Import-Module MSOnline
+      $Password = ConvertTo-SecureString -String "#{password}" -AsPlainText -Force
+      $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "#{username}", $Password
+      Connect-MsolService -Credential $Credential
+      Add-MsolRoleMember -RoleName "Company Administrator" -RoleMemberEmailAddress "#{target_user}"
+    cleanup_command: |
+      Remove-MsolRoleMember -RoleName "Company Administrator" -RoleMemberType User -RoleMemberEmailAddress "#{target_user}"
+    name: powershell
+    elevation_required: false


### PR DESCRIPTION
**Details:**
An adversary can add Company Administrator role to an existing user to retain privileged access to the Azure tenancy.

**Testing:**
Local atomic testing.
Refer screenshot

**Associated Issues:**
N/A
![T1098 003](https://github.com/blueteam0ps/atomic-red-team/assets/1480956/8b3528bc-bb2d-432e-a2ac-fbf24468da1d)
